### PR TITLE
import addObserver

### DIFF
--- a/StartupScripts/SpaceCenter-RemoveTemplateGlyphs/SpaceCenter-RemoveTemplateGlyphs.py
+++ b/StartupScripts/SpaceCenter-RemoveTemplateGlyphs/SpaceCenter-RemoveTemplateGlyphs.py
@@ -1,3 +1,5 @@
+from mojo.events import addObserver
+
 class SpaceCenterRemoveTemplateGlyphs(object):
     
     """


### PR DESCRIPTION
If the `addObserver` method is not imporoted, the RF observer cannot be added (RF 3.4b)